### PR TITLE
Add Excel-based account logging

### DIFF
--- a/excel_logger.py
+++ b/excel_logger.py
@@ -1,0 +1,37 @@
+import os
+from openpyxl import Workbook, load_workbook
+
+HEADERS = [
+    "Email",
+    "Password",
+    "First Name",
+    "Last Name",
+    "Birth Date",
+    "Proxy Host",
+    "Proxy Port",
+    "Proxy Username",
+    "Proxy Password",
+    "Created At",
+    "Col11",
+    "Col12",
+    "Col13",
+    "Col14",
+]
+
+def append_account(row_data: list):
+    file_path = "comptes.xlsx"
+    if os.path.exists(file_path):
+        wb = load_workbook(file_path)
+        ws = wb.active
+    else:
+        wb = Workbook()
+        ws = wb.active
+    if ws.max_row == 1 and all(cell.value is None for cell in ws[1]):
+        ws.append(HEADERS)
+        ws.delete_rows(1)
+    if len(row_data) < len(HEADERS):
+        row_data = row_data + ["" for _ in range(len(HEADERS) - len(row_data))]
+    else:
+        row_data = row_data[:len(HEADERS)]
+    ws.append(row_data)
+    wb.save(file_path)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import time
 import json
 from fake_data import generate_fake_data
 from check_email import check_email
+from excel_logger import append_account
 
 # Load the configuration from config.json
 with open('config.json', 'r') as f:
@@ -304,6 +305,24 @@ class AccGen:
             f.write(f"Email: {email}\n")
             f.write(f"Password: {password}\n")
             print("Email and password saved to generated.txt")
+
+        row_data = [
+            email,
+            password,
+            first_name,
+            last_name,
+            birth_date.isoformat(),
+            config.get("proxy_host", ""),
+            config.get("proxy_port", ""),
+            config.get("username", ""),
+            config.get("password", ""),
+            time.strftime("%Y-%m-%d %H:%M:%S"),
+            "",
+            "",
+            "",
+            "",
+        ]
+        append_account(row_data)
 
     def create_account(self):
         while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 selenium
 faker
 requests
+openpyxl


### PR DESCRIPTION
## Summary
- Log generated Outlook accounts to a new `comptes.xlsx` workbook via `excel_logger.append_account`
- Record account details after successful signup in `fill_signup_form`
- Include `openpyxl` dependency for Excel operations

## Testing
- `python -m py_compile main.py excel_logger.py`
- `python - <<'PY'
from excel_logger import append_account
import os
if os.path.exists('comptes.xlsx'):
    os.remove('comptes.xlsx')
append_account(list(range(14)))
append_account(list(range(14,28)))
from openpyxl import load_workbook
wb=load_workbook('comptes.xlsx')
ws=wb.active
for row in ws.iter_rows(values_only=True):
    print(row)
os.remove('comptes.xlsx')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b1d89dda083239efcc8b1fb24aed8